### PR TITLE
focus input for "add card" form / "add board" form

### DIFF
--- a/web/static/js/components/boards/form.js
+++ b/web/static/js/components/boards/form.js
@@ -32,6 +32,10 @@ export default class BoardForm extends React.Component {
     });
   }
 
+  componentDidMount(){
+    this.refs.name.getDOMNode().focus();
+  }
+
   _handleCancelClick(e) {
     e.preventDefault();
 

--- a/web/static/js/components/boards/form.js
+++ b/web/static/js/components/boards/form.js
@@ -33,7 +33,7 @@ export default class BoardForm extends React.Component {
   }
 
   componentDidMount(){
-    this.refs.name.getDOMNode().focus();
+    this.refs.name.focus();
   }
 
   _handleCancelClick(e) {

--- a/web/static/js/components/cards/form.js
+++ b/web/static/js/components/cards/form.js
@@ -34,6 +34,10 @@ export default class CardForm extends React.Component {
     });
   }
 
+  componentDidMount(){
+    this.refs.name.getDOMNode().focus();
+  }
+
   _handleCancelClick(e) {
     e.preventDefault();
 

--- a/web/static/js/components/cards/form.js
+++ b/web/static/js/components/cards/form.js
@@ -35,7 +35,7 @@ export default class CardForm extends React.Component {
   }
 
   componentDidMount(){
-    this.refs.name.getDOMNode().focus();
+    this.refs.name.focus();
   }
 
   _handleCancelClick(e) {

--- a/web/static/js/components/lists/form.js
+++ b/web/static/js/components/lists/form.js
@@ -33,6 +33,10 @@ export default class ListForm extends React.Component {
     });
   }
 
+  componentDidMount(){
+    this.refs.name.focus();
+  }
+
   _handleCancelClick(e) {
     e.preventDefault();
 


### PR DESCRIPTION
problem: 
- after clicking add card you still have to select the input manually to give it a name, that's a bit inconvenient

solution: 
- focus the input in componentDidMount callback