### PR TITLE
remove duplicate webpack dep under devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node-sass": "^3.4.2",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.13.0",
-    "webpack": "^1.12.9"
+    "webpack": "^1.12.11"
   },
   "dependencies": {
     "bourbon": "^4.2.6",
@@ -53,7 +53,6 @@
     "redux": "^3.0.5",
     "redux-logger": "^2.3.2",
     "redux-simple-router": "^2.0.3",
-    "redux-thunk": "^1.0.2",
-    "webpack": "^1.12.11"
+    "redux-thunk": "^1.0.2"
   }
 }


### PR DESCRIPTION
Remove duplicate `webpack` dependency in both `dependencies` and `devDepedencies` in `package.json`, to avoid warning:

```bash
npm WARN package.json Dependency 'webpack' exists in both dependencies and devDependencies, using 'webpack@^1.12.11' from dependencies
```

@bigardone I assume there's no good reason we need slightly different webpack versions in development vs production?