### PR TITLE
Remove unused const authToken declaration

### DIFF
--- a/web/static/js/utils/index.js
+++ b/web/static/js/utils/index.js
@@ -49,7 +49,6 @@ export function httpPost(url, data) {
 }
 
 export function httpDelete(url) {
-  const authToken = localStorage.getItem('phoenixAuthToken');
 
   return fetch(url, {
     method: 'delete',


### PR DESCRIPTION
Hi @bigardone, not sure if you are taking pull requests, and this one is very minor anyways.

In `web/static/utils/index.js@httpDelete`, there was a `const authToken` declaration that seems unnecessary with `buildHeaders()` doing that.

Thanks for this repo!