### PR TITLE
Show target when dragging cards

### DIFF
--- a/web/static/css/modules/_boards.sass
+++ b/web/static/css/modules/_boards.sass
@@ -240,15 +240,33 @@
 
       .card:not(.form)
         +transition
-        background: #fff
         margin-bottom: $base-spacing/3
-        padding: $base-spacing/3
-        border-radius: $base-border-radius
-        border-bottom: 1px solid $gray
         cursor: pointer
         animation-duration: .3s
         animation-name: fadeIn
         white-space: normal
+
+        &.isOver
+          padding-top: 50px
+          position: relative
+
+          :before
+            background: rgba($dark-gray, .1)
+            border-radius: $base-border-radius
+            content: ""
+            display: block
+            height: 40px
+            width: 100%
+            position: absolute
+            top: 0
+            left: 0
+            margin-bottom: $base-spacing/3
+
+        .card-content
+          background: #fff
+          padding: $base-spacing/3
+          border-radius: $base-border-radius
+          border-bottom: 1px solid $gray
 
         .tags-wrapper
           +clearfix

--- a/web/static/css/modules/_boards.sass
+++ b/web/static/css/modules/_boards.sass
@@ -246,7 +246,7 @@
         animation-name: fadeIn
         white-space: normal
 
-        &.isOver
+        &.is-over
           padding-top: 50px
           position: relative
 

--- a/web/static/js/components/cards/card.js
+++ b/web/static/js/components/cards/card.js
@@ -2,6 +2,7 @@ import React, {PropTypes}       from 'react';
 import {DragSource, DropTarget} from 'react-dnd';
 import { push }                 from 'react-router-redux';
 import ReactGravatar            from 'react-gravatar';
+import classnames               from 'classnames';
 
 import ItemTypes                from '../../constants/item_types';
 import Actions                  from '../../actions/current_board';
@@ -44,8 +45,9 @@ const cardTarget = {
   isDragging: monitor.isDragging()
 }))
 
-@DropTarget(ItemTypes.CARD, cardTarget, (connect) => ({
-  connectDropTarget: connect.dropTarget()
+@DropTarget(ItemTypes.CARD, cardTarget, (connect, monitor) => ({
+  connectDropTarget: connect.dropTarget(),
+  isOver: monitor.isOver()
 }))
 
 export default class Card extends React.Component {
@@ -94,18 +96,25 @@ export default class Card extends React.Component {
   }
 
   render() {
-    const { id, connectDragSource, connectDropTarget, isDragging, name } = this.props;
+    const { id, connectDragSource, connectDropTarget, isDragging, isOver, name } = this.props;
 
     const styles = {
       display: isDragging ? 'none' : 'block',
     };
 
+    const classes = classnames({
+      'card': true,
+      'isOver': isOver
+    });
+
     return connectDragSource(
       connectDropTarget(
-        <div id={`card_${id}`} className="card" style={styles} onClick={::this._handleClick}>
-          {::this._renderTags()}
-          {name}
-          {::this._renderFooter()}
+        <div id={`card_${id}`} className={classes} style={styles} onClick={::this._handleClick}>
+          <div className="card-content">
+            {::this._renderTags()}
+            {name}
+            {::this._renderFooter()}
+          </div>
         </div>
       )
     );

--- a/web/static/js/components/cards/card.js
+++ b/web/static/js/components/cards/card.js
@@ -104,7 +104,7 @@ export default class Card extends React.Component {
 
     const classes = classnames({
       'card': true,
-      'isOver': isOver
+      'is-over': isOver
     });
 
     return connectDragSource(


### PR DESCRIPTION
Adds a target area when dragging cards between lists. Implemented using CSS styles to display the card's target location while dragging based on the `monitor.isOver()` functionality in React DnD.

<img width="1280" alt="screen shot 2016-05-24 at 8 43 42 pm" src="https://cloud.githubusercontent.com/assets/461172/15524480/e18c1a14-21f0-11e6-8bc9-807ca4fb53f1.png">

A CSS based solution like this can't handle all the edge cases, like dragging cards to an empty list.

But it does handle the primary one of dragging cards around within a list and between lists very well. It works well with the CSS transition and creates a nice overall effect.

This revealed two existing drag and drop behaviors which are unrelated to these changes:

1. Picking up a card and dropping back in the same spot will cause the card to swap places with the one below it. In all other cases the behavior is for the current card to go above the card its hovering over.

2. There's some consistent failures that occur when trying to update the card order, which you can see in the console when dragging around cards.

This PR doesn't attempt to tackle either of these issues.

Hope this code helps, this is a great learning project and really shows off the power of both Phoenix + Elixir and React + Redux!