### PR TITLE
Only change card order if it has changed

### DIFF
--- a/web/static/js/views/boards/show.js
+++ b/web/static/js/views/boards/show.js
@@ -125,6 +125,9 @@ class BoardsShowView extends React.Component {
     let targetList = lists[targetListIndex];
     const targetCardIndex = targetList.cards.findIndex((card) => { return card.id === target.id; });
     const targetCard = targetList.cards[targetCardIndex];
+    const previousTargetCard = sourceList.cards[sourceCardIndex + 1];
+
+    if (previousTargetCard === targetCard) { return false; }
 
     sourceList.cards.splice(sourceCardIndex, 1);
 


### PR DESCRIPTION
When working on #30 I noticed an issue when then a card is dragged and dropped back in its original location. This pull request fixes it.

Previously picking up a card and dropping it in the same spot would cause the card to swap positions with the card below it. Now the card stays in its current position and does not dispatch an update event to the phoenix backend.

The logic here is pretty simple - check to see if the `targetCard` is the same as the card that is currently below the `sourceCard`. If it is, return early and don't update the position.

The behavior when dragging a card to a different location within the same list, or dragging to another list remains the same.

Definitely open to suggestions for improvement. Was having a hard time coming up with a meaningful variable name.

Thanks again for this project, it's been really fun reading through the code and learning 😃 