### PR TITLE
Fix index position when dragging cards down

### DIFF
--- a/web/static/js/views/boards/show.js
+++ b/web/static/js/views/boards/show.js
@@ -129,9 +129,10 @@ class BoardsShowView extends React.Component {
     sourceList.cards.splice(sourceCardIndex, 1);
 
     if (sourceList === targetList) {
+      const insertIndex = sourceCardIndex < targetCardIndex ? targetCardIndex - 1 : targetCardIndex;
       // move at once to avoid complications
       targetList = sourceList;
-      sourceList.cards.splice(targetCardIndex, 0, source);
+      sourceList.cards.splice(insertIndex, 0, source);
     } else {
       // and move it to target
       targetList.cards.splice(targetCardIndex, 0, source);


### PR DESCRIPTION
While working on #30 and #31 I kept noticing something was slightly off when I would drag cards around in the same list.

When I looked closer, I noticed moving a card up the list towards the top always worked as expected. But when I moved a card down towards the bottom of the list it would end up one position lower than the intended target.

The fix was to calculate the insert position based on its current position in the list. If the card is currently below the target, the target index will work. If the card is currently above the target, we need to subtract one from the target index.

This is because when the card moves from above to its new location, it leaves a hole in the list where it used to be. If we don't account for the "missing" card, then the card will end up one position lower than its supposed to be.

I had fun trying to reason this out. Let me know if this is still unclear, it's easier to see in code than to explain in words.

This fixes the last issue I could find with the drag behavior. Should be good from here!

Thanks for being so receptive to fixes and feedback, it's nice to be able to give back to a great project :smiley: